### PR TITLE
ドキュメントをgithub pagesにデプロイする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: deploy document page
+
+on:
+  workflow_run:
+    workflows: ["build"]
+    types:
+      - completed
+    branches:
+      - main
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+      - name: setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: install dependencies
+        run: pnpm install
+      - name: build
+        run: pnpm build:redocly
+      - name: deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist/docs

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_Store
 
 # Doc output
-dist/doc
+dist/docs
 
 # Dependency directories
 node_modules/


### PR DESCRIPTION
## issue

resolve #25 

## 概要

github actionsを利用して、redoclyのdocumentをgithub pagesにデプロイするworkflowを追加した

## 備考

正しく動くかあまり自身がない